### PR TITLE
Обновлен Writer для 5.6

### DIFF
--- a/src/Providers/Log.php
+++ b/src/Providers/Log.php
@@ -6,7 +6,7 @@
 
 namespace Nutnet\LaravelSms\Providers;
 
-use Illuminate\Log\Writer;
+use Psr\Log\LoggerInterface as Writer;
 use Nutnet\LaravelSms\Contracts\Provider;
 
 /**


### PR DESCRIPTION
В Laravel 5.6 случилось следующее:

The Illuminate\Log\Writer class has been renamed to Illuminate\Log\Logger. If you were explicitly type-hinting this class as a dependency of one of your application's classes, you should update the class reference to the new name. Or, alternatively, you should strongly consider type-hinting the standardized Psr\Log\LoggerInterface interface instead.

Обновление исправляет проблему, возникающую при обновлении на Laravel 5.6