### PR TITLE
Support "zelenin/smsru": "~5"

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ $sender->send('<phone_number>', '<your_message>', [
 ]);
 ```
 
+**Использовать собственный http-клиент вместо стандартного Zelenin\SmsRu\Client\Client:**
+
+Просто зарегистрируйте свой http-клиент (например, `App\Services\SmsRuHttpClient`) в DI-контейнере следующим образом:
+
+```php
+// app/Providers/AppServiceProvider.php
+public function register()
+{
+    $this->app->bind(\Zelenin\SmsRu\Client\ClientInterface::class, \App\Services\SmsRuHttpClient::class);
+}
+```
+
 #### Smsc.ru
 Отправка сообщений через провайдера Smsc.ru. Требует для работы установленный `curl`.
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "franzose/laravel-smpp": "Required for SMPP provider",
         "zelenin/smsru": "Required for Sms.Ru provider"
     },
+    "conflict": {
+        "zelenin/smsru": "<5.0.0"
+    },
     "extra": {
         "laravel": {
             "providers": [
@@ -35,11 +38,12 @@
         }
     },
     "require-dev": {
-        "zelenin/smsru": "^4.1",
-        "phpunit/phpunit": "^7.5",
+        "zelenin/smsru": "^5.0",
+        "phpunit/phpunit": "^7.5|^8.0",
         "illuminate/log": ">=5.0",
         "franzose/laravel-smpp": "^1.1",
-        "infection/infection": "^0.10"
+        "infection/infection": "^0.26",
+        "psr/log": "^1.0"
     },
     "scripts": {
         "test": [
@@ -51,5 +55,10 @@
         "test-mutation": [
             "PHP_BINARY=phpdbg phpdbg -qrr vendor/bin/infection --ansi"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "require-dev": {
         "zelenin/smsru": "^5.0",
-        "phpunit/phpunit": "^7.5|^8.0",
+        "phpunit/phpunit": "^9.3",
         "illuminate/log": ">=5.0",
         "franzose/laravel-smpp": "^1.1",
         "infection/infection": "^0.26",

--- a/tests/Providers/SmsRuTest.php
+++ b/tests/Providers/SmsRuTest.php
@@ -88,7 +88,7 @@ class SmsRuTest extends BaseTestCase
             'password' => 'test',
         ]);
 
-        $this->assertInstanceOf(Api::class, $provider->getClient());
+        $this->assertInstanceOf(Api::class, $provider->getApi());
     }
 
     /**
@@ -201,10 +201,10 @@ class SmsRuTest extends BaseTestCase
                     'password' => 'test',
                 ]
             ])
-            ->setMethods(['getClient'])
+            ->setMethods(['getApi'])
             ->getMock();
 
-        $provider->method('getClient')->willReturn($client);
+        $provider->method('getApi')->willReturn($client);
 
         return [$provider, $client];
     }


### PR DESCRIPTION
Adds support for "zelenin/smsru": "~5" and stop supporting <5.0 

Issue #12 